### PR TITLE
Fix: Reduce redundant LLM calls for suggested prompts

### DIFF
--- a/app.py
+++ b/app.py
@@ -460,7 +460,10 @@ def main():
                 print(f"New discussion created as fallback: {st.session_state.current_discussion_title} ({st.session_state.current_discussion_id})")
 
         st.session_state.user_id_initialized = True # Set flag to prevent re-execution of this block
-        st.rerun() # Rerun once to ensure the UI updates correctly after initial setup
+        # Removed st.rerun() here. If UI updates are needed,
+        # they should occur naturally or be triggered more specifically.
+        # This aims to prevent potential re-triggering of prompt generation
+        # if this rerun was causing should_generate_prompts to be evaluated an extra time.
 
     # --- Ensure a current discussion is always active after initial setup ---
     # This handles cases where the last discussion was deleted, or initial load failed.


### PR DESCRIPTION
I've refactored `app.py` to minimize unnecessary LLM calls for generating suggested prompts. The main change involves removing an `st.rerun()` call from the end of the initial user and discussion setup block (`if not st.session_state.user_id_initialized:`).

This ensures that the logic for generating suggested prompts runs more selectively, primarily after new content (like a new message or a discussion load) is processed, rather than potentially re-triggering on multiple `st.rerun()` calls during startup or unrelated UI updates.

This change aims to prevent hitting LLM rate limits and improve application performance by avoiding repeated regeneration of suggestions. A review also confirmed no deprecated `st.cache` decorators are in use.