### PR TITLE
Fix: Prevent redundant LLM calls during app startup

### DIFF
--- a/app.py
+++ b/app.py
@@ -408,6 +408,9 @@ def main():
             print(f"Fell back to temporary user ID: {user_id}")
 
         st.session_state.user_id = user_id
+        # !!! SET THE FLAG IMMEDIATELY AFTER USER_ID IS SECURED !!!
+        st.session_state.user_id_initialized = True 
+        print(f"User ID initialized and flag set for user: {st.session_state.user_id}") # Debug print
         
         # Populate discussion list for the first time
         st.session_state.discussion_list = sorted(
@@ -459,7 +462,7 @@ def main():
                 )
                 print(f"New discussion created as fallback: {st.session_state.current_discussion_title} ({st.session_state.current_discussion_id})")
 
-        st.session_state.user_id_initialized = True # Set flag to prevent re-execution of this block
+        # Moved st.session_state.user_id_initialized = True to earlier in the block
         # Removed st.rerun() here. If UI updates are needed,
         # they should occur naturally or be triggered more specifically.
         # This aims to prevent potential re-triggering of prompt generation

--- a/streamlit_app.log
+++ b/streamlit_app.log
@@ -1,0 +1,11 @@
+
+Collecting usage statistics. To deactivate, set browser.gatherUsageStats to false.
+
+
+  You can now view your Streamlit app in your browser.
+
+  Local URL: http://localhost:8501
+  Network URL: http://192.168.0.2:8501
+  External URL: http://34.46.237.233:8501
+
+  Stopping...

--- a/streamlit_run.log
+++ b/streamlit_run.log
@@ -1,0 +1,10 @@
+
+Collecting usage statistics. To deactivate, set browser.gatherUsageStats to false.
+
+
+  You can now view your Streamlit app in your browser.
+
+  Local URL: http://localhost:8501
+  Network URL: http://192.168.0.2:8501
+  External URL: http://34.46.237.233:8501
+


### PR DESCRIPTION
Refined the initialization logic in `app.py` to ensure the user identification and initial discussion setup block runs only once. Moved `st.session_state.user_id_initialized = True` to be set immediately after the user ID is established.

This prevents the block from being re-entered due to rapid Streamlit reruns, particularly during the initial cookie handling and component loading phase. This directly addresses the issue of multiple "Initial user/discussion setup running..." logs and the associated repeated calls to `generate_llm_greeting` and `generate_suggested_prompts` which were causing excessive LLM usage and hitting rate limits.